### PR TITLE
ConstantBackOff

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -43,3 +43,14 @@ type StopBackOff struct{}
 func (b *StopBackOff) Reset() {}
 
 func (b *StopBackOff) NextBackOff() time.Duration { return Stop }
+
+type ConstantBackoff struct {
+	RetryInterval time.Duration
+}
+
+func (b *ConstantBackoff) Reset()                     {}
+func (b *ConstantBackoff) NextBackOff() time.Duration { return b.RetryInterval }
+
+func NewConstantBackOff() *ConstantBackoff {
+	return &ConstantBackoff{RetryInterval: DefaultInitialInterval}
+}

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -19,3 +19,10 @@ func subtestNextBackOff(t *testing.T, expectedValue time.Duration, backOffPolicy
 		}
 	}
 }
+
+func TestConstantBackoff(t *testing.T) {
+	backoff := NewConstantBackOff()
+	if backoff.NextBackOff() != DefaultInitialInterval {
+		t.Error("Should have been default interval")
+	}
+}


### PR DESCRIPTION
Hi,

Thank you for your library. We've added a constant backoff to continually retry with a fixed interval. It's been useful for connecting up some of our monitoring systems when we don't want to fail after n retries and the exponential backoff interval would grow too large.

Hope it's useful for others too,
Paul
