### PR TITLE
Support contexts

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,59 @@
+package backoff
+
+import (
+	"context"
+	"time"
+)
+
+// BackOffContext is a backoff policy that stops retrying after the context
+// is canceled.
+type BackOffContext interface {
+	BackOff
+	Context() context.Context
+}
+
+type backOffContext struct {
+	BackOff
+	ctx context.Context
+}
+
+// WithContext returns a BackOffContext with context ctx
+//
+// ctx must not be nil
+func WithContext(b BackOff, ctx context.Context) BackOffContext {
+	if ctx == nil {
+		panic("nil context")
+	}
+
+	if b, ok := b.(*backOffContext); ok {
+		return &backOffContext{
+			BackOff: b.BackOff,
+			ctx:     ctx,
+		}
+	}
+
+	return &backOffContext{
+		BackOff: b,
+		ctx:     ctx,
+	}
+}
+
+func ensureContext(b BackOff) BackOffContext {
+	if cb, ok := b.(BackOffContext); ok {
+		return cb
+	}
+	return WithContext(b, context.Background())
+}
+
+func (b *backOffContext) Context() context.Context {
+	return b.ctx
+}
+
+func (b *backOffContext) NextBackOff() time.Duration {
+	select {
+	case <-b.Context().Done():
+		return Stop
+	default:
+		return b.BackOff.NextBackOff()
+	}
+}

--- a/context.go
+++ b/context.go
@@ -1,8 +1,9 @@
 package backoff
 
 import (
-	"context"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 // BackOffContext is a backoff policy that stops retrying after the context

--- a/context_test.go
+++ b/context_test.go
@@ -1,0 +1,25 @@
+package backoff
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestContext(t *testing.T) {
+	b := NewConstantBackOff(time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	cb := WithContext(b, ctx)
+
+	if cb.Context() != ctx {
+		t.Error("invalid context")
+	}
+
+	cancel()
+
+	if cb.NextBackOff() != Stop {
+		t.Error("invalid next back off")
+	}
+}

--- a/context_test.go
+++ b/context_test.go
@@ -1,9 +1,10 @@
 package backoff
 
 import (
-	"context"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 func TestContext(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -1,6 +1,9 @@
 package backoff
 
-import "log"
+import (
+	"context"
+	"log"
+)
 
 func ExampleRetry() {
 	// An operation that may fail.
@@ -9,6 +12,26 @@ func ExampleRetry() {
 	}
 
 	err := Retry(operation, NewExponentialBackOff())
+	if err != nil {
+		// Handle error.
+		return
+	}
+
+	// Operation is successful.
+}
+
+func ExampleRetryContext() {
+	// A context
+	ctx := context.Background()
+
+	// An operation that may fail.
+	operation := func() error {
+		return nil // or an error
+	}
+
+	b := WithContext(NewExponentialBackOff(), ctx)
+
+	err := Retry(operation, b)
 	if err != nil {
 		// Handle error.
 		return

--- a/example_test.go
+++ b/example_test.go
@@ -1,8 +1,9 @@
 package backoff
 
 import (
-	"context"
 	"log"
+
+	"golang.org/x/net/context"
 )
 
 func ExampleRetry() {

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,9 +1,12 @@
 package backoff
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"log"
 	"testing"
+	"time"
 )
 
 func TestRetry(t *testing.T) {
@@ -29,6 +32,40 @@ func TestRetry(t *testing.T) {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
 	if i != successOn {
+		t.Errorf("invalid number of retries: %d", i)
+	}
+}
+
+func TestRetryContext(t *testing.T) {
+	var cancelOn = 3
+	var i = 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// This function cancels context on "cancelOn" calls.
+	f := func() error {
+		i++
+		log.Printf("function is called %d. time\n", i)
+
+		// cancelling the context in the operation function is not a typical
+		// use-case, however it allows to get predictable test results.
+		if i == cancelOn {
+			cancel()
+		}
+
+		log.Println("error")
+		return fmt.Errorf("error (%d)", i)
+	}
+
+	err := Retry(f, WithContext(NewConstantBackOff(time.Millisecond), ctx))
+	if err == nil {
+		t.Errorf("error is unexpectedly nil")
+	}
+	if err.Error() != "error (3)" {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if i != cancelOn {
 		t.Errorf("invalid number of retries: %d", i)
 	}
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,12 +1,13 @@
 package backoff
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 func TestRetry(t *testing.T) {

--- a/ticker.go
+++ b/ticker.go
@@ -13,7 +13,7 @@ import (
 type Ticker struct {
 	C        <-chan time.Time
 	c        chan time.Time
-	b        BackOff
+	b        BackOffContext
 	stop     chan struct{}
 	stopOnce sync.Once
 }
@@ -26,7 +26,7 @@ func NewTicker(b BackOff) *Ticker {
 	t := &Ticker{
 		C:    c,
 		c:    c,
-		b:    b,
+		b:    ensureContext(b),
 		stop: make(chan struct{}),
 	}
 	go t.run()
@@ -57,6 +57,8 @@ func (t *Ticker) run() {
 			afterC = t.send(tick)
 		case <-t.stop:
 			t.c = nil // Prevent future ticks from being sent to the channel.
+			return
+		case <-t.b.Context().Done():
 			return
 		}
 	}

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -1,9 +1,12 @@
 package backoff
 
 import (
+	"context"
 	"errors"
+	"fmt"
 	"log"
 	"testing"
+	"time"
 )
 
 func TestTicker(t *testing.T) {
@@ -40,6 +43,51 @@ func TestTicker(t *testing.T) {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
 	if i != successOn {
+		t.Errorf("invalid number of retries: %d", i)
+	}
+}
+
+func TestTickerContext(t *testing.T) {
+	const cancelOn = 3
+	var i = 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// This function cancels context on "cancelOn" calls.
+	f := func() error {
+		i++
+		log.Printf("function is called %d. time\n", i)
+
+		// cancelling the context in the operation function is not a typical
+		// use-case, however it allows to get predictable test results.
+		if i == cancelOn {
+			cancel()
+		}
+
+		log.Println("error")
+		return fmt.Errorf("error (%d)", i)
+	}
+
+	b := WithContext(NewConstantBackOff(time.Millisecond), ctx)
+	ticker := NewTicker(b)
+
+	var err error
+	for _ = range ticker.C {
+		if err = f(); err != nil {
+			t.Log(err)
+			continue
+		}
+
+		break
+	}
+	if err == nil {
+		t.Errorf("error is unexpectedly nil")
+	}
+	if err.Error() != "error (3)" {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if i != cancelOn {
 		t.Errorf("invalid number of retries: %d", i)
 	}
 }

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -1,12 +1,13 @@
 package backoff
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
 	"testing"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 func TestTicker(t *testing.T) {


### PR DESCRIPTION
Implements #32

At the API level, this adds:

 * BackOffContext interface: A BackOff that also supports contexts
 * WithContext(BackOff, context.Context): Returns a BackOffContext from a BackOff

Retry() and Ticker still accept BackOff implementations, but also support BackOffContext implementations.