### PR TITLE
Remove checking of a constant value

### DIFF
--- a/exponential.go
+++ b/exponential.go
@@ -89,11 +89,6 @@ func NewExponentialBackOff() *ExponentialBackOff {
 		MaxElapsedTime:      DefaultMaxElapsedTime,
 		Clock:               SystemClock,
 	}
-	if b.RandomizationFactor < 0 {
-		b.RandomizationFactor = 0
-	} else if b.RandomizationFactor > 1 {
-		b.RandomizationFactor = 1
-	}
 	b.Reset()
 	return b
 }


### PR DESCRIPTION
The NewExponentialBackOff function initalizes an instance of the
ExponentialBackOff struct with the DefaultRandomizationFactor constant
as the RandomizationFactor field. It then checks if the RandomizationFactor
field of the struct is less than 0 or greater than 1.

The checks were currently not doing much since the value they were
checking is a constant and will always be between 0 and 1. The
validation would make sense if the value was provided by the caller of
the function (in this case it isn't).