### PR TITLE
Changed name of error type

### DIFF
--- a/context_pre17.go
+++ b/context_pre17.go
@@ -1,10 +1,11 @@
-// +build go1.7
+// +build !go1.7
 
 package backoff
 
 import (
-	"context"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 // BackOffContext is a backoff policy that stops retrying after the context


### PR DESCRIPTION
FatalError is a better name because it is self-explanatory.
I am doing the pull-request because the commit was very new so very few projects would have made use of this feature (backwards incompatibility)