### PR TITLE
Fixed up concerns about backwards compatibility

### DIFF
--- a/context_pre17.go
+++ b/context_pre17.go
@@ -1,10 +1,11 @@
-// +build go1.7
+// +build !go1.7
 
 package backoff
 
 import (
-	"context"
 	"time"
+
+	"golang.org/x/net/context"
 )
 
 // BackOffContext is a backoff policy that stops retrying after the context

--- a/retry.go
+++ b/retry.go
@@ -42,6 +42,11 @@ func RetryNotify(operation Operation, b BackOff, notify Notify) error {
 			return fatal.Err
 		}
 
+		//For backwards-compatibility
+		if permanent, ok := err.(*PermanentError); ok {
+			return permanent.Err
+		}
+
 		if next = b.NextBackOff(); next == Stop {
 			return err
 		}
@@ -73,6 +78,24 @@ func (e *FatalError) Error() string {
 // Fatal wraps the given err in a *FatalError.
 func Fatal(err error) *FatalError {
 	return &FatalError{
+		Err: err,
+	}
+}
+
+// Deprecated: Use FatalError instead
+// PermanentError signals that the operation should not be retried.
+type PermanentError struct {
+	Err error
+}
+
+func (e *PermanentError) Error() string {
+	return e.Err.Error()
+}
+
+// Deprecated: Use FatalError instead
+// Permanent wraps the given err in a *PermanentError.
+func Permanent(err error) *PermanentError {
+	return &PermanentError{
 		Err: err,
 	}
 }


### PR DESCRIPTION
@cenkalti 
- Changed PermanentError to FatalError (name is self-explanatory)
- Added support for Go1.7+'s context package whilst providing support for context for older versions of Go.