### PR TITLE
switch to stdlib context

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,9 +1,8 @@
 package backoff
 
 import (
+	"context"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 // BackOffContext is a backoff policy that stops retrying after the context

--- a/context_test.go
+++ b/context_test.go
@@ -1,10 +1,9 @@
 package backoff
 
 import (
+	"context"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestContext(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -1,9 +1,8 @@
 package backoff
 
 import (
+	"context"
 	"log"
-
-	"golang.org/x/net/context"
 )
 
 func ExampleRetry() {

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,13 +1,12 @@
 package backoff
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestRetry(t *testing.T) {

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -1,13 +1,12 @@
 package backoff
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestTicker(t *testing.T) {


### PR DESCRIPTION
`context` has been a part of the standard library since 1.7. 

Changing the references to the stdlib version will make backoff easier to vendor since this package will no longer have external dependencies.