### PR TITLE
Fix data race when querying GetElapsedTime()

### DIFF
--- a/ticker.go
+++ b/ticker.go
@@ -29,6 +29,7 @@ func NewTicker(b BackOff) *Ticker {
 		b:    ensureContext(b),
 		stop: make(chan struct{}),
 	}
+	t.b.Reset()
 	go t.run()
 	runtime.SetFinalizer(t, (*Ticker).Stop)
 	return t
@@ -42,7 +43,6 @@ func (t *Ticker) Stop() {
 func (t *Ticker) run() {
 	c := t.c
 	defer close(c)
-	t.b.Reset()
 
 	// Ticker is guaranteed to tick at least once.
 	afterC := t.send(time.Now())

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -30,6 +30,10 @@ func TestTicker(t *testing.T) {
 
 	b := NewExponentialBackOff()
 	ticker := NewTicker(b)
+	elapsed := b.GetElapsedTime()
+	if elapsed > time.Second {
+		t.Errorf("elapsed time too large: %v", elapsed)
+	}
 
 	var err error
 	for _ = range ticker.C {


### PR DESCRIPTION
`ExponentialBackOff.GetElapsedTime()` reads start time which is reset
by `ExponentialBackOff.Reset()` which is called by `run()`, executed
in a goroutine. This creates a data race just by using:

```go
b := NewExponentialBackOff()
ticker := backoff.NewTicker(b)
b.GetElapsedTime()
```

This commit solves this by resetting the backoff timer outside the
goroutine. The ticker test has been updated for this particular data
race.