### PR TITLE
ticker: document it's unsafe to access backoff policy while ticker running

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -15,7 +15,7 @@ import "time"
 // BackOff is a backoff policy for retrying an operation.
 type BackOff interface {
 	// NextBackOff returns the duration to wait before retrying the operation,
-	// or backoff.Stop to indicate that no more retries should be made.
+	// or backoff. Stop to indicate that no more retries should be made.
 	//
 	// Example usage:
 	//

--- a/exponential.go
+++ b/exponential.go
@@ -127,7 +127,9 @@ func (b *ExponentialBackOff) NextBackOff() time.Duration {
 // GetElapsedTime returns the elapsed time since an ExponentialBackOff instance
 // is created and is reset when Reset() is called.
 //
-// The elapsed time is computed using time.Now().UnixNano().
+// The elapsed time is computed using time.Now().UnixNano(). It is
+// safe to call even while the backoff policy is used by a running
+// ticker.
 func (b *ExponentialBackOff) GetElapsedTime() time.Duration {
 	return b.Clock.Now().Sub(b.startTime)
 }

--- a/ticker.go
+++ b/ticker.go
@@ -18,9 +18,12 @@ type Ticker struct {
 	stopOnce sync.Once
 }
 
-// NewTicker returns a new Ticker containing a channel that will send the time at times
-// specified by the BackOff argument. Ticker is guaranteed to tick at least once.
-// The channel is closed when Stop method is called or BackOff stops.
+// NewTicker returns a new Ticker containing a channel that will send
+// the time at times specified by the BackOff argument. Ticker is
+// guaranteed to tick at least once.  The channel is closed when Stop
+// method is called or BackOff stops. It is not safe to manipulate the
+// provided backoff policy (notably calling NextBackOff or Reset)
+// while the ticker is running.
 func NewTicker(b BackOff) *Ticker {
 	c := make(chan time.Time)
 	t := &Ticker{


### PR DESCRIPTION
The other way around would be to use locks to make backoff policies
thread-safe. This is not something hard to do but this would need to
be implemented in each policy. It doesn't seem unreasonable to require
the user to not modify the backoff policy while we are using it.

This would fix #47 (for some definition of "fix").