### PR TITLE
Remove SetFinalizer call

### DIFF
--- a/ticker.go
+++ b/ticker.go
@@ -34,7 +34,6 @@ func NewTicker(b BackOff) *Ticker {
 	}
 	t.b.Reset()
 	go t.run()
-	runtime.SetFinalizer(t, (*Ticker).Stop)
 	return t
 }
 


### PR DESCRIPTION
See #56, this should be doing nothing.
To shut down the goroutine, callers should cancel the context given to the ticker.