### PR TITLE
switch to the built-in context package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.3.3
+  - 1.7
   - 1.x
   - tip
 before_install:

--- a/context.go
+++ b/context.go
@@ -1,9 +1,8 @@
 package backoff
 
 import (
+	"context"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 // BackOffContext is a backoff policy that stops retrying after the context

--- a/context_test.go
+++ b/context_test.go
@@ -1,10 +1,9 @@
 package backoff
 
 import (
+	"context"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestContext(t *testing.T) {

--- a/example_test.go
+++ b/example_test.go
@@ -1,9 +1,8 @@
 package backoff
 
 import (
+	"context"
 	"log"
-
-	"golang.org/x/net/context"
 )
 
 func ExampleRetry() {

--- a/retry_test.go
+++ b/retry_test.go
@@ -1,13 +1,12 @@
 package backoff
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestRetry(t *testing.T) {

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -1,13 +1,12 @@
 package backoff
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
 	"testing"
 	"time"
-
-	"golang.org/x/net/context"
 )
 
 func TestTicker(t *testing.T) {


### PR DESCRIPTION
Go 1.7 has been released for almost 2 years now.

(it was simpler to just open a PR than to create an issue for this change)