### PR TITLE
 Return context error from RetryNotify when done 

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -59,7 +59,7 @@ func RetryNotify(operation Operation, b BackOff, notify Notify) error {
 
 		select {
 		case <-cb.Context().Done():
-			return err
+			return cb.Context().Err();
 		case <-t.C:
 		}
 	}


### PR DESCRIPTION
Previously, when the context used by RetryNotify is done, we return whatever error the last operation returned.  The last operation may have run a long time ago (especially when using exponential backoff), so returning last operation error may be very confusing.  It makes more sense to return the context's error, which indicates exactly why the context is done.

This fixes #82 