### PR TITLE
add support for custom Stop duration in ExponentialBackOff

### DIFF
--- a/exponential.go
+++ b/exponential.go
@@ -56,9 +56,10 @@ type ExponentialBackOff struct {
 	RandomizationFactor float64
 	Multiplier          float64
 	MaxInterval         time.Duration
-	// After MaxElapsedTime the ExponentialBackOff stops.
+	// After MaxElapsedTime the ExponentialBackOff returns Stop.
 	// It never stops if MaxElapsedTime == 0.
 	MaxElapsedTime time.Duration
+	Stop           time.Duration
 	Clock          Clock
 
 	currentInterval time.Duration
@@ -87,6 +88,7 @@ func NewExponentialBackOff() *ExponentialBackOff {
 		Multiplier:          DefaultMultiplier,
 		MaxInterval:         DefaultMaxInterval,
 		MaxElapsedTime:      DefaultMaxElapsedTime,
+		Stop:                Stop,
 		Clock:               SystemClock,
 	}
 	b.Reset()
@@ -113,7 +115,7 @@ func (b *ExponentialBackOff) Reset() {
 func (b *ExponentialBackOff) NextBackOff() time.Duration {
 	// Make sure we have not gone over the maximum elapsed time.
 	if b.MaxElapsedTime != 0 && b.GetElapsedTime() > b.MaxElapsedTime {
-		return Stop
+		return b.Stop
 	}
 	defer b.incrementCurrentInterval()
 	return getRandomValueFromInterval(b.RandomizationFactor, rand.Float64(), b.currentInterval)

--- a/exponential_test.go
+++ b/exponential_test.go
@@ -83,6 +83,17 @@ func TestMaxElapsedTime(t *testing.T) {
 	assertEquals(t, Stop, exp.NextBackOff())
 }
 
+func TestCustomStop(t *testing.T) {
+	var exp = NewExponentialBackOff()
+	customStop := time.Minute
+	exp.Stop = customStop
+	exp.Clock = &TestClock{start: time.Time{}.Add(10000 * time.Second)}
+	// Change the currentElapsedTime to be 0 ensuring that the elapsed time will be greater
+	// than the max elapsed time.
+	exp.startTime = time.Time{}
+	assertEquals(t, customStop, exp.NextBackOff())
+}
+
 func TestBackOffOverflow(t *testing.T) {
 	var (
 		testInitialInterval time.Duration = math.MaxInt64 / 2


### PR DESCRIPTION
The current default behavior of the ExponentialBackOff is to return `backoff.Stop` (-1) once `MaxElapsedTime` has passed. This adds support for a custom `Stop` duration that is configurable per `ExponentialBackOff` instance, with the default value set to `backoff.Stop` for backward compatibility.