### PR TITLE
fix error interface nil check

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -1,6 +1,9 @@
 package backoff
 
-import "time"
+import (
+	"reflect"
+	"time"
+)
 
 // An Operation is executing by Retry() or RetryNotify().
 // The operation will be retried using a backoff policy if it returns an error.
@@ -49,7 +52,8 @@ func RetryNotifyWithTimer(operation Operation, b BackOff, notify Notify, t Timer
 
 	b.Reset()
 	for {
-		if err = operation(); err == nil {
+		// error interface needs reflect nil check
+		if err = operation(); err == nil || reflect.ValueOf(err).IsNil() {
 			return nil
 		}
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -27,10 +27,18 @@ func (t *testTimer) C() <-chan time.Time {
 	return t.timer.C
 }
 
+type CustomErr struct {
+	Code string
+}
+
+func (c *CustomErr) Error() string {
+	return c.Code
+}
+
 func TestRetry(t *testing.T) {
 	const successOn = 3
 	var i = 0
-
+	var e *CustomErr
 	// This function is successful on "successOn" calls.
 	f := func() error {
 		i++
@@ -38,7 +46,7 @@ func TestRetry(t *testing.T) {
 
 		if i == successOn {
 			log.Println("OK")
-			return nil
+			return e
 		}
 
 		log.Println("error")

--- a/retry_test.go
+++ b/retry_test.go
@@ -27,18 +27,18 @@ func (t *testTimer) C() <-chan time.Time {
 	return t.timer.C
 }
 
-type CustomErr struct {
+type customErr struct {
 	Code string
 }
 
-func (c *CustomErr) Error() string {
+func (c *customErr) Error() string {
 	return c.Code
 }
 
 func TestRetry(t *testing.T) {
 	const successOn = 3
 	var i = 0
-	var e *CustomErr
+	var e *customErr
 	// This function is successful on "successOn" calls.
 	f := func() error {
 		i++


### PR DESCRIPTION
operation function return error interface value need reflect nil check, as empty error value does not equal nil
```Go
package main

import (
	"fmt"
	"reflect"
)

type CustomErr struct {
	Code string
}

func (c *CustomErr) Error() string {
	return c.Code
}

func isNilErr(e error) bool {
	return e == nil
}

func main() {
	var c *CustomErr
	fmt.Println(isNilErr(c))
}
```
==> false