### PR TITLE
Fix crash if nil passed to NewTickerWithTimer

### DIFF
--- a/ticker.go
+++ b/ticker.go
@@ -33,6 +33,9 @@ func NewTicker(b BackOff) *Ticker {
 // NewTickerWithTimer returns a new Ticker with a custom timer.
 // A default timer that uses system timer is used when nil is passed.
 func NewTickerWithTimer(b BackOff, timer Timer) *Ticker {
+	if timer == nil {
+		timer = &defaultTimer{}
+	}
 	c := make(chan time.Time)
 	t := &Ticker{
 		C:     c,

--- a/ticker_test.go
+++ b/ticker_test.go
@@ -87,3 +87,10 @@ func TestTickerContext(t *testing.T) {
 		t.Errorf("invalid number of retries: %d", i)
 	}
 }
+
+func TestTickerDefaultTimer(t *testing.T) {
+	b := NewExponentialBackOff()
+	ticker := NewTickerWithTimer(b, nil)
+	// ensure a timer was actually assigned, instead of remaining as nil.
+	<-ticker.C
+}


### PR DESCRIPTION
Doc for function says that passing nil for the timer argument should
cause the default system timer to be used.  Ensure that that timer is
actually assigned.