### PR TITLE
Add a Factory, FactoryFunc interfaces

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -43,6 +43,11 @@ func (b *ZeroBackOff) Reset() {}
 
 func (b *ZeroBackOff) NextBackOff() time.Duration { return 0 }
 
+func (b *ZeroBackOff) NewBackOff() BackOff {
+	copy := *b
+	return &copy
+}
+
 // StopBackOff is a fixed backoff policy that always returns backoff.Stop for
 // NextBackOff(), meaning that the operation should never be retried.
 type StopBackOff struct{}
@@ -50,6 +55,11 @@ type StopBackOff struct{}
 func (b *StopBackOff) Reset() {}
 
 func (b *StopBackOff) NextBackOff() time.Duration { return Stop }
+
+func (b *StopBackOff) NewBackOff() BackOff {
+	copy := *b
+	return &copy
+}
 
 // ConstantBackOff is a backoff policy that always returns the same backoff delay.
 // This is in contrast to an exponential backoff policy,
@@ -60,6 +70,10 @@ type ConstantBackOff struct {
 
 func (b *ConstantBackOff) Reset()                     {}
 func (b *ConstantBackOff) NextBackOff() time.Duration { return b.Interval }
+func (b *ConstantBackOff) NewBackOff() BackOff {
+	copy := *b
+	return &copy
+}
 
 func NewConstantBackOff(d time.Duration) *ConstantBackOff {
 	return &ConstantBackOff{Interval: d}

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -19,6 +19,16 @@ func subtestNextBackOff(t *testing.T, expectedValue time.Duration, backOffPolicy
 	}
 }
 
+func TestStopBackOff(t *testing.T) {
+	backoff := &StopBackOff{}
+
+	backoffCpy := backoff.NewBackOff()
+	_, ok := backoffCpy.(*StopBackOff)
+	if !ok {
+		t.Error("wrong type from NewBackOff")
+	}
+}
+
 func TestConstantBackOff(t *testing.T) {
 	backoff := NewConstantBackOff(time.Second)
 	if backoff.NextBackOff() != time.Second {
@@ -31,7 +41,9 @@ func TestConstantBackOff(t *testing.T) {
 		t.Error("wrong type from NewBackOff")
 	}
 
-	if constant.Interval != backoff.Interval {
-		t.Error("invalid interval")
+	if constant == backoff {
+		t.Error("returned backoff is the same as original")
 	}
+
+	assertEquals(t, backoff.Interval, constant.Interval)
 }

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -24,4 +24,14 @@ func TestConstantBackOff(t *testing.T) {
 	if backoff.NextBackOff() != time.Second {
 		t.Error("invalid interval")
 	}
+
+	backoffCpy := backoff.NewBackOff()
+	constant, ok := backoffCpy.(*ConstantBackOff)
+	if !ok {
+		t.Error("wrong type from NewBackOff")
+	}
+
+	if constant.Interval != backoff.Interval {
+		t.Error("invalid interval")
+	}
 }

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -29,6 +29,16 @@ func TestStopBackOff(t *testing.T) {
 	}
 }
 
+func TestZeroBackOff(t *testing.T) {
+	backoff := &ZeroBackOff{}
+
+	backoffCpy := backoff.NewBackOff()
+	_, ok := backoffCpy.(*ZeroBackOff)
+	if !ok {
+		t.Error("wrong type from NewBackOff")
+	}
+}
+
 func TestConstantBackOff(t *testing.T) {
 	backoff := NewConstantBackOff(time.Second)
 	if backoff.NextBackOff() != time.Second {

--- a/exponential.go
+++ b/exponential.go
@@ -156,3 +156,9 @@ func getRandomValueFromInterval(randomizationFactor, random float64, currentInte
 	// we want a 33% chance for selecting either 1, 2 or 3.
 	return time.Duration(minInterval + (random * (maxInterval - minInterval + 1)))
 }
+
+// NewBackOff implements Factory, and returns a copy of the exponential backoff
+func (b *ExponentialBackOff) NewBackOff() BackOff {
+	copy := *b
+	return &copy
+}

--- a/exponential_test.go
+++ b/exponential_test.go
@@ -133,7 +133,6 @@ func TestNewBackOff(t *testing.T) {
 	exp.Multiplier = testMultiplier
 	exp.MaxInterval = testMaxInterval
 	exp.MaxElapsedTime = testMaxElapsedTime
-	exp.Reset()
 
 	expCpy := exp.NewBackOff()
 	exp2, ok := expCpy.(*ExponentialBackOff)

--- a/exponential_test.go
+++ b/exponential_test.go
@@ -117,3 +117,35 @@ func assertEquals(t *testing.T, expected, value time.Duration) {
 		t.Errorf("got: %d, expected: %d", value, expected)
 	}
 }
+
+func TestNewBackOff(t *testing.T) {
+	var (
+		testInitialInterval     = 500 * time.Millisecond
+		testRandomizationFactor = 0.1
+		testMultiplier          = 2.0
+		testMaxInterval         = 5 * time.Second
+		testMaxElapsedTime      = 15 * time.Minute
+	)
+
+	exp := NewExponentialBackOff()
+	exp.InitialInterval = testInitialInterval
+	exp.RandomizationFactor = testRandomizationFactor
+	exp.Multiplier = testMultiplier
+	exp.MaxInterval = testMaxInterval
+	exp.MaxElapsedTime = testMaxElapsedTime
+	exp.Reset()
+
+	expCpy := exp.NewBackOff()
+	exp2, ok := expCpy.(*ExponentialBackOff)
+	if !ok {
+		t.Error("wrong type from NewBackoff")
+	}
+
+	if exp2 == exp {
+		t.Error("returned backoff is the same as original")
+	}
+
+	if *exp2 != *exp {
+		t.Error("backoff copy was not equal to base backoff")
+	}
+}

--- a/factory.go
+++ b/factory.go
@@ -1,0 +1,14 @@
+package backoff
+
+// A Factory creates and returns a new backoff policy
+type Factory interface {
+	NewBackOff() BackOff
+}
+
+// FactoryFunc is a function that returns a new backoff policy
+type FactoryFunc func() BackOff
+
+// NewBackOff implements Factory, allowing a FactoryFunc to be passed to anyywhere that accepts a Factory
+func (ff FactoryFunc) NewBackOff() BackOff {
+	return ff()
+}

--- a/factory_test.go
+++ b/factory_test.go
@@ -1,0 +1,22 @@
+package backoff
+
+import "testing"
+
+func TestFactoryFunc(t *testing.T) {
+	backoff := NewExponentialBackOff()
+
+	ff := FactoryFunc(func() BackOff {
+		return backoff
+	})
+
+	newBackOff := ff.NewBackOff()
+
+	expontential, ok := newBackOff.(*ExponentialBackOff)
+	if !ok {
+		t.Error("wrong type from NewBackOff")
+	}
+
+	if *expontential != *backoff {
+		t.Error("backoff was not equal to expected backoff")
+	}
+}


### PR DESCRIPTION
Often I have components in my code take a `BackOff`. In some cases, there are concurrent pieces of code that need to be using similarly configured backoffs, but since backoffs are not safe for concurrent use, I'd need to pass the goroutine a new backoff. 

It is difficult to do this when working with a `BackOff` directly, as the code doesn't know about then underlying implementation, and shouldn't. In this situation, a `Factory` would be of great use, as it would allow the code to create new backoffs on demand, and pass them into its goroutines, without having to know what the underlying implementation details of the specific backoff instance it has.

I have been using a very similar interface to this, and it has worked quite well for me. I think it would be beneficial to have it be part of the package itself, as then no separate `backoffutil` style package would be needed.