### PR TITLE
PermanentError use errors.As

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.12
+  - 1.13
   - 1.x
   - tip
 before_install:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/cenkalti/backoff/v4
 
-go 1.12
+go 1.13

--- a/retry.go
+++ b/retry.go
@@ -1,6 +1,9 @@
 package backoff
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 // An Operation is executing by Retry() or RetryNotify().
 // The operation will be retried using a backoff policy if it returns an error.
@@ -53,7 +56,8 @@ func RetryNotifyWithTimer(operation Operation, b BackOff, notify Notify, t Timer
 			return nil
 		}
 
-		if permanent, ok := err.(*PermanentError); ok {
+		var permanent *PermanentError
+		if errors.As(err, &permanent) {
 			return permanent.Err
 		}
 

--- a/retry.go
+++ b/retry.go
@@ -88,6 +88,11 @@ func (e *PermanentError) Unwrap() error {
 	return e.Err
 }
 
+func (e *PermanentError) Is(target error) bool {
+	_, ok := target.(*PermanentError)
+	return ok
+}
+
 // Permanent wraps the given err in a *PermanentError.
 func Permanent(err error) error {
 	if err == nil {

--- a/retry_test.go
+++ b/retry_test.go
@@ -117,11 +117,26 @@ func TestRetryPermanent(t *testing.T) {
 
 func TestPermanent(t *testing.T) {
 	want := errors.New("foo")
+	other := errors.New("bar")
 	var err error = Permanent(want)
 
 	got := errors.Unwrap(err)
 	if got != want {
 		t.Errorf("got %v, want %v", got, want)
+	}
+
+	if is := errors.Is(err, want); !is {
+		t.Errorf("err: %v is not %v", err, want)
+	}
+
+	if is := errors.Is(err, other); is {
+		t.Errorf("err: %v is %v", err, other)
+	}
+
+	wrapped := fmt.Errorf("wrapped: %w", err)
+	var permanent *PermanentError
+	if !errors.As(wrapped, &permanent) {
+		t.Errorf("errors.As(%v, %v)", wrapped, permanent)
 	}
 
 	err = Permanent(nil)


### PR DESCRIPTION
Fixes: https://github.com/cenkalti/backoff/issues/107

Also bumped minimal go version to 1.13 since `errors.Is/As/Unwrap` were added in 1.13. 

Note: tests on the development branch already require 1.12 since test added in https://github.com/cenkalti/backoff/commit/382faa4670ba597b20a23f9bc522ade773e957bf uses `errors.Unwrap`.