### PR TITLE
fix typos in tests

### DIFF
--- a/exponential_test.go
+++ b/exponential_test.go
@@ -108,7 +108,7 @@ func TestBackOffOverflow(t *testing.T) {
 	exp.Reset()
 
 	exp.NextBackOff()
-	// Assert that when an overflow is possible, the current varerval time.Duration is set to the max varerval time.Duration.
+	// Assert that when an overflow is possible, the current interval time.Duration is set to the max interval time.Duration.
 	assertEquals(t, testMaxInterval, exp.currentInterval)
 }
 

--- a/tries_test.go
+++ b/tries_test.go
@@ -55,7 +55,7 @@ func TestMaxTriesZero(t *testing.T) {
 	}, b)
 
 	if err == nil {
-		t.Errorf("error expected, nil founc")
+		t.Errorf("error expected, nil found")
 	}
 	if called != 1 {
 		t.Errorf("operation is called %d times", called)


### PR DESCRIPTION
Fixed a couple of typos in unit tests:
* word `interval` was wrongly written `varerval`
* `founc` should be `found`