### PR TITLE
Remove context deadline checking in backOffContext

### DIFF
--- a/context.go
+++ b/context.go
@@ -57,10 +57,6 @@ func (b *backOffContext) NextBackOff() time.Duration {
 	case <-b.ctx.Done():
 		return Stop
 	default:
+		return b.BackOff.NextBackOff()
 	}
-	next := b.BackOff.NextBackOff()
-	if deadline, ok := b.ctx.Deadline(); ok && deadline.Sub(time.Now()) < next { // nolint: gosimple
-		return Stop
-	}
-	return next
 }

--- a/retry.go
+++ b/retry.go
@@ -62,6 +62,10 @@ func RetryNotifyWithTimer(operation Operation, b BackOff, notify Notify, t Timer
 		}
 
 		if next = b.NextBackOff(); next == Stop {
+			if cerr := ctx.Err(); cerr != nil {
+				return cerr
+			}
+
 			return err
 		}
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -81,7 +81,7 @@ func TestRetryContext(t *testing.T) {
 	if err == nil {
 		t.Errorf("error is unexpectedly nil")
 	}
-	if err.Error() != "error (3)" {
+	if !errors.Is(err, context.Canceled) {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
 	if i != cancelOn {


### PR DESCRIPTION
The current implementation of `backOffContext` checks the context's deadline and marks it as cancelled even when that deadline is not reached yet. This leads to confusion on the `RetryNotifyWithTimer` caller's side, because there are no clear indications whether the execution was stopped due to the context reaching its deadline (`context.DeadlineExceeded` is not returned) or some other error. Even checking whether the context is cancelled after the retry func returns, does not work because the context itself might not have been cancelled (only `backOffContext` marked it internally as being so):
```go
b := backoff.WithContext(backoff.NewConstantBackOff(time.Second), ctx)
err := backoff.Retry(operation, b)
if err != nil {
      if cerr := ctx.Err(); cerr != nil { // there might be no error returned from the context because backOffContext only 'predicts' its cancellation
            //...
      }
}
```

