### PR TITLE
Fix package dropping error details when permanent error is wrapped

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -58,7 +58,10 @@ func RetryNotifyWithTimer(operation Operation, b BackOff, notify Notify, t Timer
 
 		var permanent *PermanentError
 		if errors.As(err, &permanent) {
-			return permanent.Err
+			if _, ok := err.(*PermanentError) {
+				return permanent.Err
+			}
+			return err
 		}
 
 		if next = b.NextBackOff(); next == Stop {


### PR DESCRIPTION
We are defining errors something like this
```go
var ErrBadInput      = backoff.Permanent(interactionError("bad input"))
```
And when using them we're often adding extra information like
```go
return fmt.Errorf("invalid phone number %w", ErrBadInput)
```

Since we added `backoff.Retry(...)` wrappers around our code we're now losing this extra information. This PR fixes this by only removing the wrapper error if it's the outer error