### PR TITLE
Update retry.go to handle hung operations

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -26,11 +26,10 @@ func (o Operation) withEmptyData() OperationWithData[struct{}] {
 // the notify function isn't called.
 type Notify func(error, time.Duration)
 
-type OperationResult struct {
+type OperationResult[T any] struct {
 	res T
 	err error
 }
-
 // Retry the operation o until it does not return error or BackOff stops.
 // o is guaranteed to be run at least once.
 //
@@ -92,12 +91,12 @@ func doRetryNotify[T any](operation OperationWithData[T], b BackOff, notify Noti
 
 	
 	for {
-		outCh := make(chan OperationResult)
+		outCh := make(chan OperationResult[T])
 		
 		// Launch the operation asynchronously
 		go func() {
 			res, err := operation()
-			outCh <- OperationResult{res, err}
+			outCh <- OperationResult[T]{res, err}
 		}()
 
 		// Then wait for a) overall timeout, b) error, c) result

--- a/retry_test.go
+++ b/retry_test.go
@@ -55,6 +55,26 @@ func TestRetry(t *testing.T) {
 	}
 }
 
+func TestRetryHangs(t *testing.T) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	f := func() error {
+		log.Printf("Test Hang")
+		time.Sleep(10 * time.Second)
+		return nil
+	}
+
+	err := RetryNotifyWithTimer(f, WithContext(NewConstantBackOff(time.Millisecond), ctx), nil, &testTimer{})
+	if err == nil {
+		t.Errorf("error is unexpectedly nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+}
+
 func TestRetryWithData(t *testing.T) {
 	const successOn = 3
 	var i = 0


### PR DESCRIPTION
Update retry.go to launch the operation in an asynchronous manner and deal with an operation that hangs