### PR TITLE
fix: the Retry function throws an error when the opts parameter is passed as nil

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -75,7 +75,9 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 
 	// Apply user-provided options to the default settings.
 	for _, opt := range opts {
-		opt(args)
+		if opt != nil {
+			opt(args)
+		}
 	}
 
 	defer args.Timer.Stop()

--- a/retry_test.go
+++ b/retry_test.go
@@ -55,6 +55,33 @@ func TestRetry(t *testing.T) {
 	}
 }
 
+func TestRetryOptionIsNil(t *testing.T) {
+	const successOn = 3
+	var i = 0
+
+	// This function is successful on "successOn" calls.
+	f := func() (bool, error) {
+		i++
+		log.Printf("function is called %d. time\n", i)
+
+		if i == successOn {
+			log.Println("OK")
+			return true, nil
+		}
+
+		log.Println("error")
+		return false, errors.New("error")
+	}
+
+	_, err := Retry(context.Background(), f, nil, nil, nil)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if i != successOn {
+		t.Errorf("invalid number of retries: %d", i)
+	}
+}
+
 func TestRetryWithData(t *testing.T) {
 	const successOn = 3
 	var i = 0


### PR DESCRIPTION
I submitted this PR because I found that the Retry function throws an error if the opts parameter is passed as nil. Therefore, I added a nil check in the source code.

Although it's unlikely that opts will be passed as nil directly, since opts is a variadic parameter, one of its elements could potentially be nil. Also, as the Retry function is a public API, it's important to ensure the robustness of the code.