### PR TITLE
updates Retry to use context.Cause

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.23
 
     - name: Build
       run: go build -v ./...

--- a/retry.go
+++ b/retry.go
@@ -101,7 +101,7 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 		}
 
 		// Stop retrying if context is cancelled.
-		if cerr := ctx.Err(); cerr != nil {
+		if cerr := context.Cause(ctx); cerr != nil {
 			return res, cerr
 		}
 
@@ -133,7 +133,7 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 		select {
 		case <-args.Timer.C():
 		case <-ctx.Done():
-			return res, ctx.Err()
+			return res, context.Cause(ctx)
 		}
 	}
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -89,8 +89,10 @@ func TestRetryContext(t *testing.T) {
 	var cancelOn = 3
 	var i = 0
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(context.Canceled)
+
+	expectedErr := errors.New("custom error")
 
 	// This function cancels context on "cancelOn" calls.
 	f := func() (bool, error) {
@@ -100,7 +102,7 @@ func TestRetryContext(t *testing.T) {
 		// cancelling the context in the operation function is not a typical
 		// use-case, however it allows to get predictable test results.
 		if i == cancelOn {
-			cancel()
+			cancel(expectedErr)
 		}
 
 		log.Println("error")
@@ -111,7 +113,7 @@ func TestRetryContext(t *testing.T) {
 	if err == nil {
 		t.Errorf("error is unexpectedly nil")
 	}
-	if !errors.Is(err, context.Canceled) {
+	if !errors.Is(err, expectedErr) {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
 	if i != cancelOn {


### PR DESCRIPTION
This diff updates `Retry` to propagate errors using `context.Cause` instead of `Context.Err`. `context.Cause` was added in go 1.20 and allows users to propagate a specific error when cancelling a context. It is backwards compatible with `Context.Error`.

* https://pkg.go.dev/context#Cause
* https://pkg.go.dev/context#WithCancelCause

resolves #157