### PR TITLE
Add a BackOffResetChannel parameter for Retry() and associated test

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -17,11 +17,12 @@ type Notify func(error, time.Duration)
 
 // retryOptions holds configuration settings for the retry mechanism.
 type retryOptions struct {
-	BackOff        BackOff       // Strategy for calculating backoff periods.
-	Timer          timer         // Timer to manage retry delays.
-	Notify         Notify        // Optional function to notify on each retry error.
-	MaxTries       uint          // Maximum number of retry attempts.
-	MaxElapsedTime time.Duration // Maximum total time for all retries.
+	BackOff             BackOff       // Strategy for calculating backoff periods.
+	Timer               timer         // Timer to manage retry delays.
+	Notify              Notify        // Optional function to notify on each retry error.
+	MaxTries            uint          // Maximum number of retry attempts.
+	MaxElapsedTime      time.Duration // Maximum total time for all retries.
+	BackoffResetChannel chan bool     // Channel to reset the backoff mechanism.
 }
 
 type RetryOption func(*retryOptions)
@@ -61,6 +62,13 @@ func WithMaxElapsedTime(d time.Duration) RetryOption {
 	}
 }
 
+// WithBackoffResetChannel sets the channel to reset the backoff mechanism.
+func WithBackoffResetChannel(ch chan bool) RetryOption {
+	return func(args *retryOptions) {
+		args.BackoffResetChannel = ch
+	}
+}
+
 // Retry attempts the operation until success, a permanent error, or backoff completion.
 // It ensures the operation is executed at least once.
 //
@@ -68,9 +76,10 @@ func WithMaxElapsedTime(d time.Duration) RetryOption {
 func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOption) (T, error) {
 	// Initialize default retry options.
 	args := &retryOptions{
-		BackOff:        NewExponentialBackOff(),
-		Timer:          &defaultTimer{},
-		MaxElapsedTime: DefaultMaxElapsedTime,
+		BackOff:             NewExponentialBackOff(),
+		Timer:               &defaultTimer{},
+		MaxElapsedTime:      DefaultMaxElapsedTime,
+		BackoffResetChannel: make(chan bool),
 	}
 
 	// Apply user-provided options to the default settings.
@@ -134,6 +143,10 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 		case <-args.Timer.C():
 		case <-ctx.Done():
 			return res, context.Cause(ctx)
+		case msg := <-args.BackoffResetChannel:
+			if msg {
+				args.BackOff.Reset()
+			}
 		}
 	}
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"sync"
 	"testing"
 	"time"
 )
@@ -222,5 +223,79 @@ func TestPermanent(t *testing.T) {
 	err = Permanent(nil)
 	if err != nil {
 		t.Errorf("got %v, want nil", err)
+	}
+}
+
+func TestBackoffReset(t *testing.T) {
+	const successOn = 3
+	var i = 0
+
+	// This function is successful on "successOn" calls.
+	f := func() (bool, error) {
+		i++
+		if i == successOn {
+			return true, nil
+		}
+		return false, errors.New("error")
+	}
+
+	regularStart := time.Now()
+	_, err := Retry(context.Background(), f, WithBackOff(NewExponentialBackOff()))
+	regularElapsed := time.Since(regularStart)
+
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if i != successOn {
+		t.Errorf("invalid number of retries: %d", i)
+	}
+
+	i = 0
+	resetChan := make(chan bool)
+	ctx, cancel := context.WithCancelCause(context.Background())
+	var wg sync.WaitGroup
+
+	backoffTestStart := time.Now()
+
+	wg.Add(1)
+	go func() {
+		_, err := Retry(context.Background(), f, WithBackOff(NewExponentialBackOff()), WithBackoffResetChannel(resetChan))
+		if err != nil {
+			t.Errorf("unexpected error: %s", err.Error())
+		}
+		if i != successOn {
+			t.Errorf("invalid number of retries: %d", i)
+		}
+		wg.Done()
+		cancel(context.Canceled)
+	}()
+
+	wg.Add(1)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				wg.Done()
+				return
+			default:
+				resetChan <- true
+				time.Sleep(5 * time.Millisecond)
+			}
+		}
+
+	}()
+
+	wg.Wait()
+	close(resetChan)
+
+	backoffTestElapsed := time.Since(backoffTestStart)
+
+	diff := regularElapsed - backoffTestElapsed
+
+	thresholdPercentage := 90.0
+	percentageDiff := (float64(diff.Milliseconds()) / float64(regularElapsed.Milliseconds())) * 100
+
+	if percentageDiff < thresholdPercentage {
+		t.Errorf("The time difference (%.2f%%) is greater than the threshold (%.2f%%)\n", percentageDiff, thresholdPercentage)
 	}
 }


### PR DESCRIPTION
Add a channel that can reset the backoff algorithm within an active Retry(). This can be useful for very long running or infinite retries.