### PR TITLE
use `math/rand/v2` instead of `math/rand`

### DIFF
--- a/exponential.go
+++ b/exponential.go
@@ -1,7 +1,7 @@
 package backoff
 
 import (
-	"math/rand"
+	"math/rand/v2"
 	"time"
 )
 

--- a/tries_test.go
+++ b/tries_test.go
@@ -4,14 +4,13 @@ package backoff
 
 import (
 	"errors"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 )
 
 func TestMaxTriesHappy(t *testing.T) {
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	max := 17 + r.Intn(13)
+	max := 17 + rand.IntN(13)
 	bo := WithMaxRetries(&ZeroBackOff{}, uint64(max))
 
 	// Load up the tries count, but reset should clear the record


### PR DESCRIPTION
This PR refactors code to use [`math/rand/v2`](https://pkg.go.dev/math/rand/v2) instead of [`math/rand`](https://pkg.go.dev/math/rand).

See https://go.dev/blog/randv2 for the benefits.