### PR TITLE
Allow for retries to be optionally result-less

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -64,8 +64,43 @@ func WithMaxElapsedTime(d time.Duration) RetryOption {
 // Retry attempts the operation until success, a permanent error, or backoff completion.
 // It ensures the operation is executed at least once.
 //
-// Returns the operation result or error if retries are exhausted or context is cancelled.
+// Returns the operation result or error if retries are exhausted, context is cancelled, or the operation returns a permanent error.
 func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOption) (T, error) {
+	var res T
+	err := retryInternal(ctx, func() (bool, error) {
+		var err error
+
+		// Execute the operation.
+		res, err = operation()
+		if err == nil {
+			return true, nil
+		}
+
+		return false, err
+	}, opts...)
+
+	return res, err
+}
+
+// RetryNoResult attempts the operation until success, a permanent error, or backoff completion.
+// It ensures the operation is executed at least once.
+//
+// Returns an error if retries are exhausted, context is cancelled, or the operation returns a permanent error.
+func RetryNoResult(ctx context.Context, operation func() error, opts ...RetryOption) error {
+	err := retryInternal(ctx, func() (bool, error) {
+		// Execute the operation
+		err := operation()
+		if err == nil {
+			return true, nil
+		}
+
+		return false, err
+	}, opts...)
+
+	return err
+}
+
+func retryInternal(ctx context.Context, innerFunc func() (bool, error), opts ...RetryOption) error {
 	// Initialize default retry options.
 	args := &retryOptions{
 		BackOff:        NewExponentialBackOff(),
@@ -83,32 +118,31 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 	startedAt := time.Now()
 	args.BackOff.Reset()
 	for numTries := uint(1); ; numTries++ {
-		// Execute the operation.
-		res, err := operation()
-		if err == nil {
-			return res, nil
+		success, err := innerFunc()
+		if success {
+			return nil
 		}
 
 		// Stop retrying if maximum tries exceeded.
 		if args.MaxTries > 0 && numTries >= args.MaxTries {
-			return res, err
+			return err
 		}
 
 		// Handle permanent errors without retrying.
 		var permanent *PermanentError
 		if errors.As(err, &permanent) {
-			return res, err
+			return err
 		}
 
 		// Stop retrying if context is cancelled.
 		if cerr := context.Cause(ctx); cerr != nil {
-			return res, cerr
+			return err
 		}
 
 		// Calculate next backoff duration.
 		next := args.BackOff.NextBackOff()
 		if next == Stop {
-			return res, err
+			return err
 		}
 
 		// Reset backoff if RetryAfterError is encountered.
@@ -120,7 +154,7 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 
 		// Stop retrying if maximum elapsed time exceeded.
 		if args.MaxElapsedTime > 0 && time.Since(startedAt)+next > args.MaxElapsedTime {
-			return res, err
+			return err
 		}
 
 		// Notify on error if a notifier function is provided.
@@ -133,7 +167,7 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 		select {
 		case <-args.Timer.C():
 		case <-ctx.Done():
-			return res, context.Cause(ctx)
+			return err
 		}
 	}
 }

--- a/retry.go
+++ b/retry.go
@@ -136,7 +136,7 @@ func retryInternal(ctx context.Context, innerFunc func() (bool, error), opts ...
 
 		// Stop retrying if context is cancelled.
 		if cerr := context.Cause(ctx); cerr != nil {
-			return err
+			return cerr
 		}
 
 		// Calculate next backoff duration.
@@ -167,7 +167,7 @@ func retryInternal(ctx context.Context, innerFunc func() (bool, error), opts ...
 		select {
 		case <-args.Timer.C():
 		case <-ctx.Done():
-			return err
+			return context.Cause(ctx)
 		}
 	}
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -55,6 +55,30 @@ func TestRetry(t *testing.T) {
 	}
 }
 
+func TestRetryNoResult(t *testing.T) {
+	const successOn = 3
+	var i = 0
+
+	// This function is successful on "successOn" calls.
+	f := func() error {
+		i++
+		log.Printf("function is called %d. time\n", i)
+
+		if i == successOn {
+			log.Println("OK")
+			return nil
+		}
+
+		log.Println("error")
+		return errors.New("error")
+	}
+
+	err := RetryNoResult(context.Background(), f, WithBackOff(NewExponentialBackOff()), withTimer(&testTimer{}))
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+}
+
 func TestRetryWithData(t *testing.T) {
 	const successOn = 3
 	var i = 0


### PR DESCRIPTION
Sometimes you just want to make sure an async request is kicked successfully but you'll handle the result elsewhere, or you're trying to write to something like a database and the only response you expect is nil (success) or an error requiring some code gymnastics to do with backoff.

This change facilitates this by adding a new method called RetryNoResult.

This was implemented by refactoring how Retry works to break out the retry logic from the return logic, this allows for different return types by using a variable captured in an anonymous function.

I'm not certain if there is a better way to go about this, but at the very least this allows for a much cleaner usage pattern when you simply do not care about returning a result
