### PR TITLE
retry: unwrap PermanentError before MaxTries check

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -89,15 +89,15 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 			return res, nil
 		}
 
-		// Stop retrying if maximum tries exceeded.
-		if args.MaxTries > 0 && numTries >= args.MaxTries {
-			return res, err
-		}
-
 		// Handle permanent errors without retrying.
 		var permanent *PermanentError
 		if errors.As(err, &permanent) {
 			return res, permanent.Unwrap()
+		}
+
+		// Stop retrying if maximum tries exceeded.
+		if args.MaxTries > 0 && numTries >= args.MaxTries {
+			return res, err
 		}
 
 		// Stop retrying if context is cancelled.


### PR DESCRIPTION
Fixes #177: ensure PermanentError is unwrapped before MaxTries check so callers receive the underlying error when using WithMaxTries(1).