### PR TITLE
retry: always include last operation error on timeout or context cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.0.0] - 2026-02-21
+
+### Changed
+
+- `Retry` now returns `errors.Join(context.Cause(ctx), lastErr)` when the context is cancelled, instead of returning only the context error. This ensures the last operation error is always available to the caller.
+- `Retry` now returns `errors.Join(context.DeadlineExceeded, lastErr)` when `WithMaxElapsedTime` is exceeded, instead of returning only the operation error. This makes timeout behaviour consistent regardless of whether the deadline comes from the context or `WithMaxElapsedTime`. (#181)
+
+See [`ExampleRetry_outcomes`](example_test.go) for how to inspect the different error outcomes.
+
 ## [5.0.0] - 2024-12-19
 
 ### Added

--- a/example_test.go
+++ b/example_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/cenkalti/backoff/v5"
 )
@@ -52,6 +53,44 @@ func ExampleRetry() {
 
 	fmt.Println(result)
 	// Output: hello
+}
+
+func ExampleRetry_outcomes() {
+	operation := func() (string, error) {
+		resp, err := http.Get("http://httpbin.org/get")
+		if err != nil {
+			return "", err
+		}
+		defer resp.Body.Close()
+		return "ok", nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	result, err := backoff.Retry(ctx, operation,
+		backoff.WithMaxElapsedTime(10*time.Second),
+		backoff.WithMaxTries(5),
+	)
+
+	switch {
+	case err == nil:
+		// Operation succeeded.
+		fmt.Println(result)
+
+	case errors.Is(err, context.Canceled):
+		// Context was cancelled by the caller.
+		fmt.Println("cancelled:", err)
+
+	case errors.Is(err, context.DeadlineExceeded):
+		// Either the context deadline or WithMaxElapsedTime was reached.
+		// err contains both the timeout signal and the last operation error.
+		fmt.Println("timed out:", err)
+
+	default:
+		// Retries exhausted (MaxTries or backoff stopped) or Permanent error.
+		fmt.Println("retries exhausted:", err)
+	}
 }
 
 func ExampleTicker() {

--- a/retry.go
+++ b/retry.go
@@ -102,7 +102,7 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 
 		// Stop retrying if context is cancelled.
 		if cerr := context.Cause(ctx); cerr != nil {
-			return res, cerr
+			return res, errors.Join(cerr, err)
 		}
 
 		// Calculate next backoff duration.
@@ -120,7 +120,7 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 
 		// Stop retrying if maximum elapsed time exceeded.
 		if args.MaxElapsedTime > 0 && time.Since(startedAt)+next > args.MaxElapsedTime {
-			return res, err
+			return res, errors.Join(context.DeadlineExceeded, err)
 		}
 
 		// Notify on error if a notifier function is provided.
@@ -133,7 +133,7 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 		select {
 		case <-args.Timer.C():
 		case <-ctx.Done():
-			return res, context.Cause(ctx)
+			return res, errors.Join(context.Cause(ctx), err)
 		}
 	}
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -121,6 +121,50 @@ func TestRetryContext(t *testing.T) {
 	}
 }
 
+// https://github.com/cenkalti/backoff/issues/181
+func TestRetryContextErrorIncludesOperationError(t *testing.T) {
+	opErr := errors.New("operation error")
+	ctxErr := errors.New("context error")
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	defer cancel(nil)
+
+	i := 0
+	f := func() (bool, error) {
+		i++
+		if i == 2 {
+			cancel(ctxErr)
+		}
+		return false, opErr
+	}
+
+	_, err := Retry(ctx, f, WithBackOff(NewConstantBackOff(time.Millisecond)), withTimer(&testTimer{}))
+	if !errors.Is(err, ctxErr) {
+		t.Errorf("context error not in result: %v", err)
+	}
+	if !errors.Is(err, opErr) {
+		t.Errorf("operation error not in result: %v", err)
+	}
+}
+
+// https://github.com/cenkalti/backoff/issues/181
+func TestRetryMaxElapsedTimeErrorIncludesOperationError(t *testing.T) {
+	opErr := errors.New("operation error")
+
+	_, err := Retry(
+		context.Background(),
+		func() (bool, error) { return false, opErr },
+		WithMaxElapsedTime(time.Millisecond),
+		withTimer(&testTimer{}),
+	)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("DeadlineExceeded not in result: %v", err)
+	}
+	if !errors.Is(err, opErr) {
+		t.Errorf("operation error not in result: %v", err)
+	}
+}
+
 func TestRetryPermanent(t *testing.T) {
 	ensureRetries := func(test string, shouldRetry bool, f func() (int, error), expectRes int) {
 		numRetries := -1


### PR DESCRIPTION
## Summary

- `Retry` now returns `errors.Join(context.Cause(ctx), lastErr)` when the context is cancelled, ensuring the last operation error is always available alongside the context error.
- `Retry` now returns `errors.Join(context.DeadlineExceeded, lastErr)` when `WithMaxElapsedTime` is exceeded, making timeout behaviour consistent regardless of whether the deadline comes from the context or `WithMaxElapsedTime`.

Closes #181
