### PR TITLE
fix: PermanentError.Is should match by identity, not by type

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -148,9 +148,21 @@ func (e *PermanentError) Unwrap() error {
 	return e.Err
 }
 
+// Is reports whether target is the same *PermanentError instance as e or one
+// of its wrapped errors. The previous implementation returned true for any
+// *PermanentError target, which made errors.Is treat every PermanentError as
+// equal to every other. Callers wrapping distinct sentinel errors with
+// Permanent(...) could no longer distinguish them with errors.Is.
+//
+// Identity is preserved here so callers can still detect "is this a
+// permanent error" with errors.As and inspect Err, while errors.Is only
+// matches the same instance. See issue #186.
 func (e *PermanentError) Is(target error) bool {
-	_, ok := target.(*PermanentError)
-	return ok
+	t, ok := target.(*PermanentError)
+	if !ok {
+		return false
+	}
+	return e == t
 }
 
 // Permanent wraps the given err in a *PermanentError.

--- a/retry_test.go
+++ b/retry_test.go
@@ -222,3 +222,50 @@ func TestPermanent(t *testing.T) {
 		t.Errorf("got %v, want nil", err)
 	}
 }
+
+// TestPermanentIsByIdentity guards against the regression described in
+// issue #186: PermanentError.Is previously returned true for any
+// *PermanentError target, which made errors.Is(Permanent(A), Permanent(B))
+// incorrectly report a match. Two distinct wrapped sentinels must remain
+// distinguishable.
+func TestPermanentIsByIdentity(t *testing.T) {
+	sentinelA := errors.New("sentinel A")
+	sentinelB := errors.New("sentinel B")
+
+	permA := Permanent(sentinelA)
+	permB := Permanent(sentinelB)
+
+	// Two calls to Permanent with the same wrapped error must produce
+	// distinct *PermanentError instances, so errors.Is must not equate them.
+	permA2 := Permanent(sentinelA)
+	if errors.Is(permA, permA2) {
+		t.Errorf("errors.Is(permA, permA2): different *PermanentError instances wrapping the same error must not match")
+	}
+
+	// Different wrapped errors must never match.
+	if errors.Is(permA, permB) {
+		t.Errorf("errors.Is(Permanent(A), Permanent(B)): distinct wrapped errors matched (issue #186)")
+	}
+	if errors.Is(permB, permA) {
+		t.Errorf("errors.Is(Permanent(B), Permanent(A)): distinct wrapped errors matched (issue #186)")
+	}
+
+	// Identity must still match itself.
+	if !errors.Is(permA, permA) {
+		t.Errorf("errors.Is(permA, permA): identity must match itself")
+	}
+
+	// A *PermanentError target that lives in the wrapped chain still matches
+	// via errors.Is's identity check (errors.Is walks Unwrap and reaches permA
+	// itself in the chain).
+	wrappedA := fmt.Errorf("wrap: %w", permA)
+	if !errors.Is(wrappedA, permA) {
+		t.Errorf("errors.Is(wrapped(permA), permA): permA must be reachable via Unwrap")
+	}
+
+	// But the unrelated permB is not reachable from permA's chain, so it
+	// must not match wrapped(permA).
+	if errors.Is(wrappedA, permB) {
+		t.Errorf("errors.Is(wrapped(permA), permB): permB is not in wrappedA's chain")
+	}
+}


### PR DESCRIPTION
Closes #186

The previous implementation of `(*PermanentError).Is` returned true for any `*PermanentError` target, which made `errors.Is` treat every `PermanentError` as equal to every other. Callers wrapping distinct sentinel errors with `Permanent(...)` could no longer distinguish them with `errors.Is`.

Change `Is` to compare `target` against `e` by identity (pointer equality) after confirming `target` is a `*PermanentError`. The previous "is this a permanent error at all" check is still served by `errors.As`, which lets callers inspect `.Err` on the matched `*PermanentError`.

Reproduction from the issue:

```go
package main

import (
	"errors"
	"fmt"

	"github.com/cenkalti/backoff/v4"
)

func main() {
	a := backoff.Permanent(errors.New("a"))
	b := backoff.Permanent(errors.New("b"))
	fmt.Println(errors.Is(a, b)) // before fix: true (BUG); after fix: false
}
```

The existing `TestPermanent` contract still holds:

- `errors.Is(Permanent(want), want)` is true (via `Unwrap`)
- `errors.Is(Permanent(want), other)` is false
- `errors.As(fmt.Errorf("wrapped: %w", err), &perm)` finds the `*PermanentError`

A new `TestPermanentIsByIdentity` covers the regression scenarios specifically called out in the issue: two `Permanent()` calls wrapping distinct sentinel errors must not match each other under `errors.Is`, and a wrapped `*PermanentError` is still reachable through `errors.Is` via the `Unwrap` chain.

The reported real-world impact is in [evcc-io/evcc#33171](https://github.com/evcc-io/evcc/issues/33171), where merging several permanent sentinel types caused `errors.Is` against any one of them to also match the others, masking real configuration failures. After this fix, each sentinel is checked by identity and the misbehavior is corrected.

v7 already redesigned this API and uses a different sentinel approach that does not suffer from the same bug, so no change is needed there. This commit targets the v4 branch which is what downstream consumers such as evcc currently use.

Tests:

```
go test -v -run TestPermanent -race ./...
```

All existing tests pass; the new `TestPermanentIsByIdentity` passes as well.
