### PR TITLE
retry: add WithMaxElapsedTimeSinceFirstFailure

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ result, err := backoff.Retry(ctx, func() (string, error) {
 `Retry` runs the operation at least once and keeps retrying with exponential
 backoff until it succeeds, returns a `Permanent` error, or a limit is reached.
 See [example_test.go][example] for a fuller example, and the [package docs][godoc]
-for the available options (`WithBackOff`, `WithMaxTries`, `WithMaxElapsedTime`,
+for the available options (`WithBackOff`, `WithMaxTries`, `WithMaxElapsedTime`, `WithMaxElapsedTimeSinceFirstFailure`,
 `WithNotify`).
 
 If `Retry` does not fit your needs, copy it from [retry.go][retry-src] and adapt it.
@@ -76,7 +76,8 @@ Mark an error non-retriable with `backoff.Permanent(err)`; `Retry` stops immedia
 Two independent limits cap how long `Retry` runs, and they behave differently:
 
 - A **context deadline** (`context.WithTimeout`) is reactive: it interrupts the wait between attempts and — if your operation observes the context — can abort an in-flight attempt. `Retry` reports it as `context.DeadlineExceeded`.
-- **`WithMaxElapsedTime`** bounds only retry scheduling: it is checked between attempts, never interrupts a running operation, and is reported as `ErrMaxElapsedTime`.
+- **`WithMaxElapsedTime`** bounds only retry scheduling from when `Retry` is called (includes attempt runtime): it is checked between attempts, never interrupts a running operation, and is reported as `ErrMaxElapsedTime`.
+- **`WithMaxElapsedTimeSinceFirstFailure`** is the same kind of bound, but the clock starts at the first failed attempt.
 
 `WithMaxElapsedTime` defaults to 15 minutes, so **both limits are active unless you override it** — pass `backoff.WithMaxElapsedTime(0)` to rely solely on the context.
 

--- a/retry.go
+++ b/retry.go
@@ -22,11 +22,12 @@ type Notify func(error, time.Duration)
 
 // retryOptions holds configuration settings for the retry mechanism.
 type retryOptions struct {
-	BackOff        BackOff       // Strategy for calculating backoff periods.
-	Timer          timer         // Timer to manage retry delays.
-	Notify         Notify        // Optional function called before each backoff wait.
-	MaxTries       uint          // Maximum number of retry attempts.
-	MaxElapsedTime time.Duration // Maximum total time for all retries.
+	BackOff                         BackOff       // Strategy for calculating backoff periods.
+	Timer                           timer         // Timer to manage retry delays.
+	Notify                          Notify        // Optional function called before each backoff wait.
+	MaxTries                        uint          // Maximum number of retry attempts.
+	MaxElapsedTime                  time.Duration // Maximum total time for all retries, from Retry call.
+	MaxElapsedTimeSinceFirstFailure time.Duration // Maximum time from first failure; 0 disables.
 }
 
 // RetryOption configures the behavior of Retry.
@@ -69,8 +70,10 @@ func WithMaxTries(n uint) RetryOption {
 }
 
 // WithMaxElapsedTime limits the total wall-clock time spent retrying, measured
-// from when Retry is called. When the limit is reached, Retry returns a
-// *RetryError with Cause ErrMaxElapsedTime.
+// from when Retry is called (including the runtime of attempts themselves).
+// Long-running operations that can outlive this window before they fail need
+// their own bound, or WithMaxElapsedTimeSinceFirstFailure. When the limit is
+// reached, Retry returns a *RetryError with Cause ErrMaxElapsedTime.
 //
 // The limit is checked only between attempts: it gates whether another attempt
 // is scheduled. It does not interrupt an operation that is already running, nor
@@ -88,6 +91,22 @@ func WithMaxTries(n uint) RetryOption {
 func WithMaxElapsedTime(d time.Duration) RetryOption {
 	return func(args *retryOptions) {
 		args.MaxElapsedTime = d
+	}
+}
+
+// WithMaxElapsedTimeSinceFirstFailure limits wall-clock time spent retrying,
+// measured from the first failed attempt rather than from when Retry is called.
+// Use this when attempts can legitimately run longer than the retry window
+// (long polls, blocking receives) and you still want retries after the first
+// failure. When the limit is reached, Retry returns a *RetryError with Cause
+// ErrMaxElapsedTime.
+//
+// Like WithMaxElapsedTime, the limit is checked only between attempts. Pass 0
+// (the default) to disable. It may be combined with WithMaxElapsedTime; both
+// limits are checked independently when set.
+func WithMaxElapsedTimeSinceFirstFailure(d time.Duration) RetryOption {
+	return func(args *retryOptions) {
+		args.MaxElapsedTimeSinceFirstFailure = d
 	}
 }
 
@@ -121,12 +140,17 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 	defer args.Timer.Stop()
 
 	startedAt := time.Now()
+	var firstFailureAt time.Time
 	args.BackOff.Reset()
 	for numTries := uint(1); ; numTries++ {
 		// Execute the operation.
 		res, err := operation()
 		if err == nil {
 			return res, nil
+		}
+
+		if firstFailureAt.IsZero() {
+			firstFailureAt = time.Now()
 		}
 
 		// Stop immediately on a permanent error; surface it as a RetryError.
@@ -169,6 +193,9 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 
 		// Stop retrying if maximum elapsed time exceeded.
 		if args.MaxElapsedTime > 0 && time.Since(startedAt)+next > args.MaxElapsedTime {
+			return res, &RetryError{LastErr: lastErr, Cause: ErrMaxElapsedTime}
+		}
+		if args.MaxElapsedTimeSinceFirstFailure > 0 && time.Since(firstFailureAt)+next > args.MaxElapsedTimeSinceFirstFailure {
 			return res, &RetryError{LastErr: lastErr, Cause: ErrMaxElapsedTime}
 		}
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -588,3 +588,53 @@ func TestRetryErrorString(t *testing.T) {
 		t.Error("AsRetryError(nil) should be nil")
 	}
 }
+
+func TestRetryMaxElapsedTimeSinceFirstFailure(t *testing.T) {
+	// First attempt blocks past WithMaxElapsedTime; with the call-time window
+	// alone Retry would stop without a second try. Measuring from the first
+	// failure lets the short retry succeed.
+	attempts := 0
+	res, err := Retry(context.Background(), func() (string, error) {
+		attempts++
+		if attempts == 1 {
+			time.Sleep(50 * time.Millisecond)
+			return "", errors.New("connection lost")
+		}
+		return "ok", nil
+	},
+		WithMaxElapsedTime(0),
+		WithMaxElapsedTimeSinceFirstFailure(time.Second),
+		WithBackOff(NewConstantBackOff(time.Millisecond)),
+		withTimer(&testTimer{}),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res != "ok" {
+		t.Fatalf("got %q, want ok", res)
+	}
+	if attempts != 2 {
+		t.Fatalf("attempts=%d, want 2", attempts)
+	}
+}
+
+func TestRetryMaxElapsedTimeIncludesAttemptRuntime(t *testing.T) {
+	// Call-time window still includes attempt runtime: a first attempt that
+	// outlives the window is not retried.
+	attempts := 0
+	_, err := Retry(context.Background(), func() (string, error) {
+		attempts++
+		time.Sleep(30 * time.Millisecond)
+		return "", errors.New("connection lost")
+	},
+		WithMaxElapsedTime(10*time.Millisecond),
+		WithBackOff(NewConstantBackOff(time.Millisecond)),
+		withTimer(&testTimer{}),
+	)
+	if !errors.Is(err, ErrMaxElapsedTime) {
+		t.Fatalf("want ErrMaxElapsedTime, got %v", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts=%d, want 1", attempts)
+	}
+}


### PR DESCRIPTION
Fixes #188.

Adds `WithMaxElapsedTimeSinceFirstFailure` so the retry window can start at the first error instead of when `Retry` is called. Clarifies that `WithMaxElapsedTime` includes attempt runtime.