### PR TITLE
Avoid overflow when checking the elapsed-time limit

### DIFF
--- a/retry.go
+++ b/retry.go
@@ -168,7 +168,7 @@ func Retry[T any](ctx context.Context, operation Operation[T], opts ...RetryOpti
 		}
 
 		// Stop retrying if maximum elapsed time exceeded.
-		if args.MaxElapsedTime > 0 && time.Since(startedAt)+next > args.MaxElapsedTime {
+		if args.MaxElapsedTime > 0 && next > args.MaxElapsedTime-time.Since(startedAt) {
 			return res, &RetryError{LastErr: lastErr, Cause: ErrMaxElapsedTime}
 		}
 

--- a/retry_test.go
+++ b/retry_test.go
@@ -588,3 +588,30 @@ func TestRetryErrorString(t *testing.T) {
 		t.Error("AsRetryError(nil) should be nil")
 	}
 }
+
+func TestRetryElapsedTimeOverflow(t *testing.T) {
+	operationErr := errors.New("retry me")
+	for _, retryAfter := range []bool{false, true} {
+		t.Run(fmt.Sprint(retryAfter), func(t *testing.T) {
+			calls := 0
+			tm := &spyTimer{}
+			_, err := Retry(context.Background(), func() (int, error) {
+				calls++
+				if calls > 1 {
+					return 1, nil
+				}
+				if retryAfter {
+					return 0, &RetryAfterError{Duration: time.Duration(1<<63 - 1)}
+				}
+				return 0, operationErr
+			}, WithBackOff(NewConstantBackOff(time.Duration(1<<63-1))),
+				WithMaxElapsedTime(time.Second), withTimer(tm))
+			if !errors.Is(err, ErrMaxElapsedTime) {
+				t.Fatalf("error = %v, want ErrMaxElapsedTime", err)
+			}
+			if calls != 1 || len(tm.starts) != 0 {
+				t.Errorf("calls = %d, waits = %v; want one call and no wait", calls, tm.starts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This replaces https://github.com/cenkalti/backoff/pull/190, which was accidentally closed and its source fork deleted. The implementation is unchanged; the original discussion and reviews remain linked there.

---

The elapsed-time check adds `time.Since(startedAt)` to the next delay. A delay near the maximum `time.Duration` overflows that sum to a negative value, so Retry accepts a wait of centuries despite a one-second elapsed-time limit.

Compare the delay with the remaining budget instead. Regression cases cover both a constant backoff policy and `RetryAfterError`; the existing spy timer makes the failure deterministic without waiting. Both cases incorrectly retry and succeed before the change, and now stop with `ErrMaxElapsedTime` before starting the timer.

Validation: `go test -race -cover ./...` passes (95.5% coverage), as do `go vet ./...` and `staticcheck ./...`.
